### PR TITLE
Export the PathTool so that the shared inheritance can be reused from…

### DIFF
--- a/packages/react-paperjs-editor/src/components/index.js
+++ b/packages/react-paperjs-editor/src/components/index.js
@@ -6,3 +6,4 @@ export { default as RectangleTool } from './RectangleTool';
 export { default as CircleTool } from './CircleTool';
 export { default as SegmentPathTool } from './SegmentPathTool';
 export { default as PanAndZoom } from './PanAndZoom';
+export { default as PathTool } from './shared/PathTool';


### PR DESCRIPTION
… the package

This could allow adopters to import the PathTool to make their own Tools.