### PR TITLE
Check for existence of 'window' before use

### DIFF
--- a/src/Paper.renderer.js
+++ b/src/Paper.renderer.js
@@ -86,7 +86,12 @@ const defaultHostConfig = {
   ) {
     return text;
   },
-  scheduleDeferredCallback: window.requestIdleCallback,
+  scheduleDeferredCallback:
+    typeof window !== 'undefined'
+      ? window.requestIdleCallback
+      : function dummyRequestIdleCallback(callback, options = {}) {
+        setTimeout(callback, options.timeout);
+      },
   prepareForCommit() {
     // console.log('ignore prepare for commit');
   },


### PR DESCRIPTION
Ran into an issue using this module with Next JS since it does some SSR, even disabling SSR for the component using Paper didn't seem to help. 

There is no `requestIdleCallback` in Node (https://github.com/nodejs/node/issues/2543) so I opted for `setTimeout` which seems like it would at least result in semi-compatible behavior. This function will probably never be used when doing SSR anyway.